### PR TITLE
Implement basic frontend with reporting form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Thumbs.db
 # Local development
 .cache/
 coverage/
+public/config.js

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ A web application that helps users find hospitals in Abuja with the shortest eme
    SUPABASE_URL=your_supabase_url
    SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
    ```
+   Copy `public/config.sample.js` to `public/config.js` and fill in your
+   `SUPABASE_URL` and `public` anon key so the front-end can connect.
 
 4. Set up the database:
    - Run the SQL in `scripts/setup_db.sql` in your Supabase SQL editor
@@ -38,9 +40,10 @@ A web application that helps users find hospitals in Abuja with the shortest eme
 
 ## Development
 
-Start the development server:
+Build the front-end and open `public/index.html` with any static server:
 ```bash
-npm run dev
+npm run build
+npx http-server public
 ```
 
 ## Project Structure

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp dist/src/app.js public/app.js",
     "seed": "tsx scripts/seed_hospitals.ts",
     "import-osm": "tsx scripts/import_osm.ts"
   },

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,93 @@
+import { createClient } from '@supabase/supabase-js';
+const supabaseUrl = window.SUPABASE_URL;
+const supabaseKey = window.SUPABASE_ANON_KEY;
+const supabase = createClient(supabaseUrl, supabaseKey);
+async function fetchHospitals(query = '') {
+    const { data, error } = await supabase
+        .from('hospitals')
+        .select(`*, aggregated_wait(est_wait, report_count, last_updated)`) // left join view
+        .ilike('name', `%${query}%`)
+        .order('name');
+    if (error) {
+        console.error('Error fetching hospitals', error.message);
+        return [];
+    }
+    return data;
+}
+function renderHospitals(list) {
+    const container = document.getElementById('hospital-list');
+    container.innerHTML = '';
+    const template = document.getElementById('report-template');
+    list.forEach((h) => {
+        const li = document.createElement('li');
+        li.innerHTML = `<strong>${h.name}</strong><br />` +
+            `Wait: ${h.aggregated_wait?.est_wait ?? 'n/a'} min` +
+            (h.aggregated_wait?.last_updated ? ` (updated ${new Date(h.aggregated_wait.last_updated).toLocaleTimeString()})` : '') +
+            `<br />Reports: ${h.aggregated_wait?.report_count ?? 0}`;
+        const clone = template.content.cloneNode(true);
+        const form = clone.querySelector('form');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const formData = new FormData(form);
+            const wait = formData.get('wait');
+            const capacity = formData.get('capacity');
+            const comment = formData.get('comment');
+            const { error } = await supabase.from('reports').insert({
+                hospital_id: h.id,
+                wait_minutes: wait ? Number(wait) : null,
+                capacity_enum: capacity ? Number(capacity) : null,
+                comment: comment || null,
+            });
+            if (error) {
+                alert('Failed to submit');
+                console.error(error.message);
+            }
+            else {
+                form.reset();
+            }
+        });
+        li.appendChild(clone);
+        container.appendChild(li);
+    });
+}
+async function refresh(query = '') {
+    const hospitals = await fetchHospitals(query);
+    renderHospitals(hospitals);
+}
+// Auth
+const loginForm = document.getElementById('login-form');
+const authStatus = document.getElementById('auth-status');
+loginForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('login-email').value;
+    const { error } = await supabase.auth.signInWithOtp({ email });
+    if (error) {
+        authStatus.textContent = 'Error sending magic link';
+        console.error(error.message);
+    }
+    else {
+        authStatus.textContent = 'Check your email for the login link';
+    }
+});
+supabase.auth.onAuthStateChange((_event, session) => {
+    if (session) {
+        authStatus.textContent = `Signed in as ${session.user.email}`;
+        loginForm.style.display = 'none';
+    }
+    else {
+        authStatus.textContent = '';
+        loginForm.style.display = 'block';
+    }
+});
+// Search functionality
+const searchInput = document.getElementById('search');
+searchInput.addEventListener('input', () => {
+    refresh(searchInput.value);
+});
+// Realtime updates
+supabase
+    .channel('public:reports')
+    .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'reports' }, () => refresh(searchInput.value))
+    .subscribe();
+refresh();
+//# sourceMappingURL=app.js.map

--- a/public/config.sample.js
+++ b/public/config.sample.js
@@ -1,0 +1,3 @@
+// Copy this file to config.js and fill in your Supabase credentials
+window.SUPABASE_URL = 'https://your-project.supabase.co';
+window.SUPABASE_ANON_KEY = 'public-anon-key';

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Abuja Hospital Wait Times</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="config.js"></script>
+</head>
+<body>
+  <h1>Abuja Hospital Wait Times</h1>
+
+  <section id="auth-section">
+    <form id="login-form">
+      <input type="email" id="login-email" placeholder="Email" required />
+      <button type="submit">Send Magic Link</button>
+    </form>
+    <div id="auth-status"></div>
+  </section>
+
+  <input type="text" id="search" placeholder="Search hospitals" />
+  <ul id="hospital-list"></ul>
+
+  <template id="report-template">
+    <form class="report-form">
+      <input type="number" name="wait" min="0" placeholder="Wait minutes" />
+      <select name="capacity">
+        <option value="2">Plenty</option>
+        <option value="1">Limited</option>
+        <option value="0">Full</option>
+      </select>
+      <input type="text" name="comment" placeholder="Optional comment" />
+      <button type="submit">Submit</button>
+    </form>
+  </template>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,14 @@
+body {
+  font-family: sans-serif;
+  margin: 1rem;
+}
+
+#hospital-list li {
+  margin-bottom: 1rem;
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+}
+
+.report-form {
+  margin-top: 0.5rem;
+}

--- a/scripts/import_osm.ts
+++ b/scripts/import_osm.ts
@@ -38,7 +38,7 @@ out body;
     throw new Error(`Overpass error: ${res.status} ${res.statusText}`);
   }
 
-  const data = await res.json();
+  const data: any = await res.json();
   return data.elements as OverpassElement[];
 }
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,124 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = (window as any).SUPABASE_URL;
+const supabaseKey = (window as any).SUPABASE_ANON_KEY;
+const supabase: SupabaseClient = createClient(supabaseUrl, supabaseKey);
+
+interface Hospital {
+  id: string;
+  name: string;
+  lat: number;
+  lon: number;
+  address: string | null;
+  phone: string | null;
+  website: string | null;
+  aggregated_wait?: {
+    est_wait: number | null;
+    report_count: number | null;
+    last_updated: string | null;
+  } | null;
+}
+
+async function fetchHospitals(query = ''): Promise<Hospital[]> {
+  const { data, error } = await supabase
+    .from('hospitals')
+    .select(`*, aggregated_wait(est_wait, report_count, last_updated)`) // left join view
+    .ilike('name', `%${query}%`)
+    .order('name');
+
+  if (error) {
+    console.error('Error fetching hospitals', error.message);
+    return [];
+  }
+  return data as Hospital[];
+}
+
+function renderHospitals(list: Hospital[]) {
+  const container = document.getElementById('hospital-list') as HTMLUListElement;
+  container.innerHTML = '';
+  const template = document.getElementById('report-template') as HTMLTemplateElement;
+
+  list.forEach((h) => {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${h.name}</strong><br />` +
+      `Wait: ${h.aggregated_wait?.est_wait ?? 'n/a'} min` +
+      (h.aggregated_wait?.last_updated ? ` (updated ${new Date(h.aggregated_wait.last_updated).toLocaleTimeString()})` : '') +
+      `<br />Reports: ${h.aggregated_wait?.report_count ?? 0}`;
+
+    const clone = template.content.cloneNode(true) as HTMLElement;
+    const form = clone.querySelector('form') as HTMLFormElement;
+
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const formData = new FormData(form);
+      const wait = formData.get('wait');
+      const capacity = formData.get('capacity');
+      const comment = formData.get('comment');
+
+      const { error } = await supabase.from('reports').insert({
+        hospital_id: h.id,
+        wait_minutes: wait ? Number(wait) : null,
+        capacity_enum: capacity ? Number(capacity) : null,
+        comment: comment || null,
+      });
+      if (error) {
+        alert('Failed to submit');
+        console.error(error.message);
+      } else {
+        form.reset();
+      }
+    });
+
+    li.appendChild(clone);
+    container.appendChild(li);
+  });
+}
+
+async function refresh(query = '') {
+  const hospitals = await fetchHospitals(query);
+  renderHospitals(hospitals);
+}
+
+// Auth
+const loginForm = document.getElementById('login-form') as HTMLFormElement;
+const authStatus = document.getElementById('auth-status') as HTMLElement;
+
+loginForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const email = (document.getElementById('login-email') as HTMLInputElement).value;
+  const { error } = await supabase.auth.signInWithOtp({ email });
+  if (error) {
+    authStatus.textContent = 'Error sending magic link';
+    console.error(error.message);
+  } else {
+    authStatus.textContent = 'Check your email for the login link';
+  }
+});
+
+supabase.auth.onAuthStateChange((_event, session) => {
+  if (session) {
+    authStatus.textContent = `Signed in as ${session.user.email}`;
+    loginForm.style.display = 'none';
+  } else {
+    authStatus.textContent = '';
+    loginForm.style.display = 'block';
+  }
+});
+
+// Search functionality
+const searchInput = document.getElementById('search') as HTMLInputElement;
+searchInput.addEventListener('input', () => {
+  refresh(searchInput.value);
+});
+
+// Realtime updates
+supabase
+  .channel('public:reports')
+  .on(
+    'postgres_changes',
+    { event: 'INSERT', schema: 'public', table: 'reports' },
+    () => refresh(searchInput.value)
+  )
+  .subscribe();
+
+refresh();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,6 @@
     "esm": true,
     "experimentalSpecifierResolution": "node"
   },
-  "include": ["scripts/**/*.ts", "types/**/*.d.ts"],
+  "include": ["scripts/**/*.ts", "src/**/*.ts", "types/**/*.d.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- set up ignore rule for front-end config
- include a basic browser client with login, search, reporting form and realtime updates
- wire TypeScript build to copy the front-end script
- update config and build instructions
- adjust Overpass import script for stricter TypeScript

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684211a266c08323b724590b8f080587