### PR TITLE
Add materialized view refresh function

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ aggregated_wait
   est_wait INT
   report_count INT
   updated_at TIMESTAMPTZ
+  -- refreshed every 15 min by an edge function
 
 -- view for analytics
 daily_report_counts
@@ -232,3 +233,10 @@ Footnotes
 4. Put hospital info in `scripts/hospitals.csv` (see example row).
 5. Execute `npm run seed` to upload hospitals to Supabase.
 6. Or run `npm run import-osm` to fetch hospital data from OpenStreetMap and upload it automatically.
+7. Deploy the refresh function to Supabase and schedule it every 15 minutes:
+   ```bash
+   supabase functions deploy refresh_aggregated_wait --no-verify-jwt
+   ```
+   In the Supabase dashboard, open **Edge Functions → Schedules** and set the
+   `refresh_aggregated_wait` function to run every 15 minutes. If you prefer,
+   any external cron service can hit the function URL on the same interval.

--- a/supabase/functions/refresh_aggregated_wait/index.ts
+++ b/supabase/functions/refresh_aggregated_wait/index.ts
@@ -1,0 +1,19 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+// Simple edge function that refreshes the materialized view
+Deno.serve(async () => {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL");
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  if (!supabaseUrl || !serviceKey) {
+    console.error("Missing Supabase env vars");
+    return new Response("Missing env vars", { status: 500 });
+  }
+
+  const client = createClient(supabaseUrl, serviceKey);
+  const { error } = await client.rpc('refresh_aggregated_wait');
+  if (error) {
+    console.error(error.message);
+    return new Response(`Error: ${error.message}`, { status: 500 });
+  }
+  return new Response("ok", { status: 200 });
+});


### PR DESCRIPTION
## Summary
- change `aggregated_wait` to a materialized view
- add refresh function and an Edge Function to call it
- document how to deploy the scheduled job

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684213820aa883238eec00889e1d57d7