### PR TITLE
Add color-coded wait times

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A web application that helps users find hospitals in Abuja with the shortest eme
 ## Features
 
 - View hospital locations on an interactive map
-- See current wait times and bed availability
+- See current wait times and bed availability, color-coded by delay
 - Submit anonymous wait time reports
 - Filter hospitals by distance and current wait times
 

--- a/public/app.js
+++ b/public/app.js
@@ -101,15 +101,20 @@ function renderHospitals(hospitals) {
 
   hospitals.forEach(hospital => {
     const popupContent = document.createElement('div');
-    const waitTime = hospital.aggregated_wait?.est_wait !== undefined ? 
-      hospital.aggregated_wait.est_wait : 'n/a';
-    const lastUpdated = hospital.aggregated_wait?.last_updated ? 
+    const waitMinutes = hospital.aggregated_wait?.est_wait;
+    const waitTime = waitMinutes !== undefined && waitMinutes !== null ?
+      waitMinutes : 'n/a';
+    const waitClass = typeof waitMinutes !== 'number' ? 'wait-unknown'
+      : waitMinutes <= 15 ? 'wait-short'
+      : waitMinutes <= 30 ? 'wait-medium'
+      : 'wait-long';
+    const lastUpdated = hospital.aggregated_wait?.last_updated ?
       ` (updated ${new Date(hospital.aggregated_wait.last_updated).toLocaleTimeString()})` : '';
     const reportCount = hospital.aggregated_wait?.report_count || 0;
 
     popupContent.innerHTML = `
       <strong>${hospital.name}</strong><br>
-      Wait: ${waitTime} min${lastUpdated}<br>
+      Wait: <span class="${waitClass}">${waitTime}</span> min${lastUpdated}<br>
       Reports: ${reportCount}
     `;
 

--- a/public/style.css
+++ b/public/style.css
@@ -43,3 +43,19 @@ body {
   color: #555;
   margin-top: 1rem;
 }
+
+.wait-short {
+  color: green;
+}
+
+.wait-medium {
+  color: orange;
+}
+
+.wait-long {
+  color: red;
+}
+
+.wait-unknown {
+  color: #555;
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -70,8 +70,16 @@ function renderHospitals(list: Hospital[]) {
 
   list.forEach((h) => {
     const popupContent = document.createElement('div');
+
+    const wait = h.aggregated_wait?.est_wait;
+    const waitClass =
+      wait == null ? 'wait-unknown'
+      : wait <= 15 ? 'wait-short'
+      : wait <= 30 ? 'wait-medium'
+      : 'wait-long';
+
     popupContent.innerHTML = `<strong>${h.name}</strong><br />` +
-      `Wait: ${h.aggregated_wait?.est_wait ?? 'n/a'} min` +
+      `Wait: <span class="${waitClass}">${wait ?? 'n/a'}</span> min` +
       (h.aggregated_wait?.last_updated ? ` (updated ${new Date(h.aggregated_wait.last_updated).toLocaleTimeString()})` : '') +
       `<br />Reports: ${h.aggregated_wait?.report_count ?? 0}`;
 


### PR DESCRIPTION
## Summary
- color-code wait times in popups
- expose wait colors in styles
- document color-coded wait times feature

## Testing
- `npm run build` *(fails: Property 'supabase' does not exist on type 'Window & typeof globalThis')*

------
https://chatgpt.com/codex/tasks/task_e_6842247148c48323a8959f042f9121f2