### PR TITLE
Fix Mapbox import error

### DIFF
--- a/public/src/app.js
+++ b/public/src/app.js
@@ -1,5 +1,3 @@
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
 // Initialize Supabase
 const supabase = window.supabase.createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
 // Initialize Mapbox
@@ -184,3 +182,4 @@ supabase
     .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'reports' }, () => refresh(searchInput.value))
     .subscribe();
 refresh();
+export {};

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,8 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { Hospital, Report } from './types';
-import mapboxgl from 'mapbox-gl';
-import 'mapbox-gl/dist/mapbox-gl.css';
+// Mapbox GL is loaded via a CDN script in index.html
+// Declare the global variable for TypeScript to avoid compile errors
+declare const mapboxgl: any;
 
 // Initialize Supabase
 const supabase = window.supabase.createClient(


### PR DESCRIPTION
## Summary
- avoid unresolved module specifier error by relying on the CDN-loaded Mapbox library

## Testing
- `npm install`
- `./node_modules/.bin/tsc`

------
https://chatgpt.com/codex/tasks/task_e_684601c5bb848323a26605f59ea69df8